### PR TITLE
Add RSS feed to CAPNow

### DIFF
--- a/firmament/feeds.py
+++ b/firmament/feeds.py
@@ -1,0 +1,20 @@
+from django.contrib.syndication.views import Feed
+#from django.urls import reverse
+from firmament.models import Case
+
+class LatestEntriesFeed(Feed):
+    title = "Feed of CAPNow cases"
+    link = "/cases/"
+    description = "a stream of cases"
+
+    def items(self):
+        return Case.objects.order_by('-year')[:5]
+
+    def item_title(self, item):
+        return item.short_name
+
+    def item_description(self, item):
+        return "%s | %s | %s" % (item.short_name, item.year, item.status)
+
+    def item_link(self, item):
+        return "http://anastaisas-link-to-the-xml-version" #reverse('news-item', args=[item.pk])

--- a/firmament/urls.py
+++ b/firmament/urls.py
@@ -18,14 +18,16 @@ from django.conf.urls import url, include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
+from firmament.feeds import LatestEntriesFeed
+
 
 from . import views
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('api.urls', namespace='api')),
-
     url(r'^public$', views.public, name='public'),
+    url(r'^latest/feed/$', LatestEntriesFeed()),
     url(r'^$', TemplateView.as_view(template_name='index.html'), name='home')
 ]
 


### PR DESCRIPTION
This logic exposes Djanog's rss logic for cases in capnow. Hopefully @ChefAndy can consume this feed?